### PR TITLE
libde265 1.0.15 rebuild ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,14 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libde265${SHLIB_EXT}      # [unix]
-    - test -f $PREFIX/include/libde265/de265.h      # [unix]
-    - test -f $PREFIX/lib/pkgconfig/libde265.pc      # [unix]
-    - test -f $PREFIX/lib/cmake/libde265/libde265Config.cmake      # [unix]
-    - if not exist %LIBRARY_LIB%\de265.lib exit 1       # [win]
-    - if not exist %LIBRARY_BIN%\libde265.dll exit 1       # [win]
-    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1       # [win]
-    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265Config.cmake exit 1       # [win]
+    - test -f $PREFIX/lib/libde265${SHLIB_EXT}                              # [unix]
+    - test -f $PREFIX/include/libde265/de265.h                              # [unix]
+    - test -f $PREFIX/lib/pkgconfig/libde265.pc                             # [unix]
+    - test -f $PREFIX/lib/cmake/libde265/libde265Config.cmake               # [unix]
+    - if not exist %LIBRARY_LIB%\de265.lib exit 1                           # [win]
+    - if not exist %LIBRARY_BIN%\libde265.dll exit 1                        # [win]
+    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1                    # [win]
+    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265Config.cmake exit 1 # [win]
     - dec265 -h
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,11 @@ about:
     multithreading and includes SSE optimizations. The decoder includes all
     features of the Main profile and correctly decodes almost all conformance
     streams.
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  license_file: COPYING
+  license: LGPL-3.0-or-later AND MIT
+  license_family: Other
+  license_file:
+    - COPYING         # LGPL 3.0
+    - dec265/COPYING  # MIT for examples
   doc_url: https://github.com/strukturag/libde265/wiki/Decoder-API-Tutorial
   dev_url: https://github.com/strukturag/libde265
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - dec265 -h
 
 about:
-  home: http://www.libde265.org/
+  home: https://www.libde265.org/
   summary: Open h.265 video codec implementation
   description: |
     libde265 is an open source implementation of the h.265 video codec.
@@ -46,6 +46,7 @@ about:
   license: LGPL-3.0-or-later
   license_family: LGPL
   license_file: COPYING
+  doc_url: https://github.com/strukturag/libde265/wiki/Decoder-API-Tutorial
   dev_url: https://github.com/strukturag/libde265
 
 extra:


### PR DESCRIPTION
libde265 1.0.15 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6335]
- dev_url:        https://github.com/strukturag/libde265/tree/v1.0.15
- conda_forge:    https://github.com/conda-forge/libde265-feedstock
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

Despite building several commits the CI barfed on the merge commit saying that `main` didn't exist.

- feedstock deleted and re-added to aggregate
- aligned comments (for something to do)


[PKG-6335]: https://anaconda.atlassian.net/browse/PKG-6335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ